### PR TITLE
Makes `ATTableView.source` public. 

### DIFF
--- a/Source/ATTableView.swift
+++ b/Source/ATTableView.swift
@@ -52,7 +52,7 @@ public class ATTableView: UITableView {
     }
     
     // Keep referrence to models, encapsulated into LazyTableViewSection.
-    private var source = [ATTableViewSection]()
+    public var source = [ATTableViewSection]()
     
     // Keep all setup for each CellType registered.
     private var mappings = [Mapping]()


### PR DESCRIPTION
This makes it easier to access TableView items for constraints, triggers and other purposes.
